### PR TITLE
Add shared spinner include and script

### DIFF
--- a/includes/spinner.php
+++ b/includes/spinner.php
@@ -1,0 +1,3 @@
+<div id="spinner" class="spinner-overlay" style="display:none;">
+  <div class="spinner"></div>
+</div>

--- a/manage.php
+++ b/manage.php
@@ -47,6 +47,7 @@ function cost_jpy(int $c): int {
 </style>
 </head>
 <body>
+<?php include 'includes/spinner.php'; ?>
 
 <header>
   <h1>アップロード済みファイル一覧</h1>
@@ -95,7 +96,7 @@ function cost_jpy(int $c): int {
           <td>
             <div class="inline-form-wrap">
               <!-- 翻訳再実行form -->
-              <form method="post" action="translate.php">
+              <form method="post" action="translate.php" onsubmit="showSpinner()">
                 <input type="hidden" name="filename" value="<?= htmlspecialchars($f) ?>">
                 <select name="out_fmt">
                   <option value="pdf">PDF</option>
@@ -119,5 +120,6 @@ function cost_jpy(int $c): int {
 </main>
 
 <footer>&copy; 2025 翻訳ツール</footer>
+<script src="spinner.js"></script>
 </body>
 </html>

--- a/spinner.js
+++ b/spinner.js
@@ -1,0 +1,9 @@
+function showSpinner() {
+  var s = document.getElementById('spinner');
+  if (s) s.style.display = 'flex';
+}
+function hideSpinner() {
+  var s = document.getElementById('spinner');
+  if (s) s.style.display = 'none';
+}
+document.addEventListener('DOMContentLoaded', hideSpinner);

--- a/upload_file.php
+++ b/upload_file.php
@@ -85,6 +85,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['stage'] ?? '') === 'upload
   </style>
 </head>
 <body>
+<?php include 'includes/spinner.php'; ?>
 <header>
   <h1>ファイルアップロード</h1>
   <nav><a href="index.html">トップへ</a></nav>
@@ -101,7 +102,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['stage'] ?? '') === 'upload
 <?php if ($step === 'form'): ?>
   <h2>アップロード</h2>
   <?php if ($message): ?><p style="color:red;"><?= $message ?></p><?php endif; ?>
-  <form action="upload_file.php" method="post" enctype="multipart/form-data">
+  <form action="upload_file.php" method="post" enctype="multipart/form-data" onsubmit="showSpinner()">
     <input type="hidden" name="stage" value="upload">
     <div class="upload-section">
       <input type="file" name="upload_file" required><br><br>
@@ -113,7 +114,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['stage'] ?? '') === 'upload
   <p>ファイル名: <?= htmlspecialchars($filename) ?></p>
   <p>文字数: <?= number_format($chars) ?> 文字</p>
   <p>概算料金: ￥<?= number_format($costJpy) ?></p>
-  <form action="translate.php" method="post">
+  <form action="translate.php" method="post" onsubmit="showSpinner()">
     <input type="hidden" name="filename" value="<?= htmlspecialchars($filename) ?>">
     <label>出力形式:
       <select name="out_fmt" required>
@@ -126,5 +127,6 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['stage'] ?? '') === 'upload
 <?php endif; ?>
 </div>
 </main>
+<script src="spinner.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- move spinner markup to `includes/spinner.php`
- create `spinner.js` for spinner logic
- load spinner snippet and script in `manage.php` and `upload_file.php`

## Testing
- `php -l manage.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68554f3808448331ac665954edfe5460