### PR TITLE
Add XLSX file support

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,8 @@ DeepL Translation Tool (PHP)
 - 以下の Composer パッケージ  
     - [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv)  
     - [`mpdf/mpdf`](https://github.com/mpdf/mpdf)  
-    - [`phpoffice/phpword`](https://github.com/PHPOffice/PHPWord)  
+    - [`phpoffice/phpword`](https://github.com/PHPOffice/PHPWord)
+    - [`phpoffice/phpspreadsheet`](https://github.com/PHPOffice/PhpSpreadsheet)
     - [`smalot/pdfparser`](https://github.com/smalot/pdfparser)
 
 ## セットアップ
@@ -17,7 +18,7 @@ DeepL Translation Tool (PHP)
 1. **Composerパッケージのインストール**
 
     ```bash
-    composer require vlucas/phpdotenv mpdf/mpdf phpoffice/phpword smalot/pdfparser
+    composer require vlucas/phpdotenv mpdf/mpdf phpoffice/phpword phpoffice/phpspreadsheet smalot/pdfparser
     ```
 
 2. **php-zip拡張のインストール・有効化**
@@ -60,11 +61,12 @@ DeepL Translation Tool (PHP)
 
 1. `index.html` にアクセス
 2. 左のメニューから「ファイルアップロード」をクリックし、翻訳したいファイルをアップロード
-3. `upload_file.php` からファイル（**TXT, PDF, DOCX**）をアップロード（最大 20 MB）
+3. `upload_file.php` からファイル（**TXT, PDF, DOCX, XLSX**）をアップロード（最大 20 MB）
 4. 文字数を自動計算し、**概算料金**を表示
-5. 出力形式を **PDF か DOCX** から選択し、`translate.php` が DeepL API で翻訳  
-    - `.txt` は「PDF」または「DOCX」どちらも選択可能  
+5. 出力形式を **PDF・DOCX・XLSX** から選択し、`translate.php` が DeepL API で翻訳
+    - `.txt` は「PDF」または「DOCX」どちらも選択可能
     - `.pdf` アップロード時は**仕様上「PDF出力のみ」**（DeepL APIの制約）
+    - `.xlsx` アップロード時は**仕様上「XLSX出力のみ」**
 6. 完成したファイルは `downloads.php` でダウンロード可能
 7. `manage.php` ではアップロード済みファイルの**削除や再翻訳**が可能
 8. アップロード履歴は `logs/history.csv` に記録
@@ -80,6 +82,7 @@ DeepL Translation Tool (PHP)
 - **DeepL APIでは PDF, DOCX, XLSX の翻訳は1回につき最低50,000文字分がカウントされます。**  
   テストにはできるだけ `.txt` ファイルを使うことを推奨します。
 - **PDFファイルをアップロードした場合、出力形式はPDFのみ選択可能**です（DeepL APIの仕様です）。
+- **XLSXファイルをアップロードした場合、出力形式はXLSXのみ選択可能**です。
 - `.env` ファイルの**Webアクセス遮断とパーミッション制御**を必ず行ってください。
 
 ## その他

--- a/manage.php
+++ b/manage.php
@@ -102,6 +102,7 @@ function cost_jpy(int $c): int {
                 <select name="out_fmt">
                   <option value="pdf">PDF</option>
                   <option value="docx">DOCX</option>
+                  <option value="xlsx">XLSX</option>
                 </select>
                 <button type="submit">翻訳再実行</button>
               </form>

--- a/translate.php
+++ b/translate.php
@@ -14,8 +14,8 @@ define('DEEPL_KEY', $_ENV['DEEPL_AUTH_KEY'] ?? '');
 
 /* パラメータ取得 */
 $filename = $_POST['filename'] ?? '';
-$fmt      = $_POST['out_fmt']  ?? '';             // pdf | docx
-if (!in_array($fmt, ['pdf','docx'], true)) die('不正な形式');
+$fmt      = $_POST['out_fmt']  ?? '';             // pdf | docx | xlsx
+if (!in_array($fmt, ['pdf','docx','xlsx'], true)) die('不正な形式');
 
 $src = __DIR__ . '/uploads/' . basename($filename);
 if (!is_file($src)) die('元ファイルが見つかりません');
@@ -92,11 +92,15 @@ if ($ext === 'txt') {
 }
 
 /*====================================================================
-  B) .pdf / .docx  →  DeepL Document-API
+  B) .pdf / .docx / .xlsx  →  DeepL Document-API
 ====================================================================*/
 // DeepL API: PDFアップロード時はPDFしか出力不可
-if ($ext === 'pdf' && $fmt === 'docx') {
-    die('DeepL API仕様上、PDF→Word形式はサポートされていません。PDFでのみ出力可能です。');
+if ($ext === 'pdf' && $fmt !== 'pdf') {
+    die('DeepL API仕様上、PDF→他形式はサポートされていません。PDFでのみ出力可能です。');
+}
+// DeepL API: XLSXアップロード時はXLSXしか出力不可
+if ($ext === 'xlsx' && $fmt !== 'xlsx') {
+    die('DeepL API仕様上、XLSX→他形式はサポートされていません。XLSXでのみ出力可能です。');
 }
 
 $up = curl_init('https://api.deepl.com/v2/document');
@@ -146,6 +150,7 @@ fclose($in); fclose($out);
 // ファイル名拡張子
 $actual_ext = $fmt;
 if ($ext === 'pdf') $actual_ext = 'pdf';
+if ($ext === 'xlsx') $actual_ext = 'xlsx';
 if ($ext === 'docx') $actual_ext = $fmt;
 
 $save = $base . '_jp.' . $actual_ext;

--- a/upload_file.php
+++ b/upload_file.php
@@ -4,6 +4,7 @@ require_once __DIR__ . '/vendor/autoload.php';
 
 use Smalot\PdfParser\Parser as PdfParser;
 use PhpOffice\PhpWord\IOFactory as WordIO;
+use PhpOffice\PhpSpreadsheet\IOFactory as SheetIO;
 
 const MAX_BYTES = 20 * 1024 * 1024; // 20 MB
 const RATE_JPY_PER_MILLION = 2500;
@@ -24,6 +25,18 @@ function count_chars_local(string $p, string $e): int|false {
       foreach ($w->getSections() as $s) {
         foreach ($s->getElements() as $e) {
           if (method_exists($e, 'getText')) $t .= $e->getText();
+        }
+      }
+      return mb_strlen($t);
+    })($p),
+    'xlsx' => (function ($q) {
+      $s = SheetIO::load($q);
+      $t = '';
+      foreach ($s->getAllSheets() as $sh) {
+        foreach ($sh->toArray(null, true, true, true) as $row) {
+          foreach ($row as $cell) {
+            $t .= $cell;
+          }
         }
       }
       return mb_strlen($t);
@@ -121,6 +134,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && ($_POST['stage'] ?? '') === 'upload
       <select name="out_fmt" required>
         <option value="pdf">PDF</option>
         <option value="docx">DOCX</option>
+        <option value="xlsx">XLSX</option>
       </select>
     </label>
     <button type="submit">翻訳実行</button>


### PR DESCRIPTION
## Summary
- allow XLSX uploads and outputs
- integrate PhpSpreadsheet for reading XLSX files
- update upload and management UI options
- enforce output restrictions for PDF and XLSX
- document new dependency and usage details

## Testing
- `php -l upload_file.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68676465a6088331a42822f8598ef788