### PR TITLE
Fix document API result path

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -172,7 +172,7 @@ if ($stat['status']!=='done') {
 /* ダウンロード */
 $tmp = tempnam($dlDir,'tmp_');
 $in  = fopen(
-    "https://api.deepl.com/v1/document/$id/result?auth_key=".DEEPL_KEY."&document_key=$key",
+    "https://api.deepl.com/v2/document/$id/result?auth_key=".DEEPL_KEY."&document_key=$key",
     'rb');
 if ($in === false) {
     error_log('Document-API result download failed');


### PR DESCRIPTION
## Summary
- update the download endpoint for DeepL Document API

## Testing
- `php -l translate.php` *(fails: `php: command not found`)*

------
https://chatgpt.com/codex/tasks/task_e_6867c08f1e908331a2b3409e064d0514