### PR TITLE
Restrict download directory permissions

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -23,7 +23,7 @@ if (!is_file($src)) die('元ファイルが見つかりません');
 $ext    = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
 $base   = pathinfo($filename, PATHINFO_FILENAME);
 $dlDir  = __DIR__ . '/downloads';
-if (!is_dir($dlDir)) mkdir($dlDir, 0777, true);
+if (!is_dir($dlDir)) mkdir($dlDir, 0755, true);
 
 /*====================================================================
   A) .txt  →  DeepL Text-API  →  PDFまたはDOCX


### PR DESCRIPTION
## Summary
- Use 0755 instead of world-writable 0777 when creating the downloads directory.
- Ensure the downloads directory has safe permissions.

## Testing
- `php -l translate.php`


------
https://chatgpt.com/codex/tasks/task_e_68a089d33cdc8331ae0b63a52cb637dc