### PR TITLE
Allow translating PDFs to DOCX

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ DeepL Translation Tool (PHP)
 4. 文字数を自動計算し、**概算料金**を表示
 5. 出力形式を **PDF・DOCX・XLSX** から選択し、`translate.php` が DeepL API で翻訳
     - `.txt` は「PDF」または「DOCX」どちらも選択可能
-    - `.pdf` アップロード時は**仕様上「PDF出力のみ」**（DeepL APIの制約）
+    - `.pdf` アップロード時は「PDF」または「DOCX」どちらも選択可能
     - `.xlsx` アップロード時は**仕様上「XLSX出力のみ」**
 6. 完成したファイルは `downloads.php` でダウンロード可能
 7. `manage.php` ではアップロード済みファイルの**削除や再翻訳**が可能
@@ -81,7 +81,7 @@ DeepL Translation Tool (PHP)
 
 - **DeepL APIでは PDF, DOCX, XLSX の翻訳は1回につき最低50,000文字分がカウントされます。**  
   テストにはできるだけ `.txt` ファイルを使うことを推奨します。
-- **PDFファイルをアップロードした場合、出力形式はPDFのみ選択可能**です（DeepL APIの仕様です）。
+- **PDFファイルをアップロードした場合、出力形式はPDFまたはDOCXを選択可能**です。
 - **XLSXファイルをアップロードした場合、出力形式はXLSXのみ選択可能**です。
 - `.env` ファイルの**Webアクセス遮断とパーミッション制御**を必ず行ってください。
 

--- a/translate.php
+++ b/translate.php
@@ -211,9 +211,9 @@ if ($ext === 'xlsx') {
 /*====================================================================
   C) .pdf / .docx  →  DeepL Document-API
 ====================================================================*/
-// DeepL API: PDFアップロード時はPDFしか出力不可
-if ($ext === 'pdf' && $fmt !== 'pdf') {
-    die('DeepL API仕様上、PDF→他形式はサポートされていません。PDFでのみ出力可能です。');
+// DeepL API: PDFアップロード時はPDFまたはDOCXが出力可能
+if ($ext === 'pdf' && $fmt === 'xlsx') {
+    die('DeepL API仕様上、PDF→XLSXはサポートされていません。');
 }
 
 $up = curl_init('https://api.deepl.com/v2/document');
@@ -289,8 +289,6 @@ fclose($out);
 
 // ファイル名拡張子
 $actual_ext = $fmt;
-if ($ext === 'pdf') $actual_ext = 'pdf';
-if ($ext === 'docx') $actual_ext = $fmt;
 
 $save = $base . '_jp.' . $actual_ext;
 rename($tmp, "$dlDir/$save");

--- a/upload_file.php
+++ b/upload_file.php
@@ -75,7 +75,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 if ($ext === 'txt') {
                     $fmtOptions = '<option value="pdf">PDF</option><option value="docx">DOCX</option>';
                 } elseif ($ext === 'pdf') {
-                    $fmtOptions = '<option value="pdf">PDF</option>';
+                    $fmtOptions = '<option value="pdf">PDF</option><option value="docx">DOCX</option>';
                 } elseif ($ext === 'xlsx') {
                     $fmtOptions = '<option value="xlsx">XLSX</option>';
                 } else {


### PR DESCRIPTION
## Summary
- enable docx output when uploading PDFs
- remove PDF-only restriction in translator and adjust README

## Testing
- `php -l upload_file.php translate.php`


------
https://chatgpt.com/codex/tasks/task_e_68b12e3cbb2483319bcd89ade1bf31f6