### PR TITLE
Apply minimum cost pricing for uploaded files

### DIFF
--- a/manage.php
+++ b/manage.php
@@ -22,7 +22,7 @@ if (($h = fopen(__DIR__ . '/logs/history.csv', 'r'))) {
     fclose($h);
 }
 function cost_jpy(int $c): int {
-    return (int)round($c / 1_000_000 * RATE_JPY_PER_MILLION);
+    return (int)round(max(50000, $c) / 1_000_000 * RATE_JPY_PER_MILLION);
 }
 ?>
 <!doctype html>


### PR DESCRIPTION
## Summary
- Show actual character counts for uploaded files
- Apply 50k-character minimum charge (125 JPY) and per-character pricing above that threshold
- Update management page to use new cost calculation

## Testing
- `php -l upload_file.php manage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b63d7d8f7483319952faf35e8c81b8