### PR TITLE
Add directory verification for file deletions

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -14,8 +14,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   }
   if (!empty($_POST['delete'])) {
     foreach ($_POST['delete'] as $f) {
-      $path = $dir . '/' . basename($f);
-      if (is_file($path)) unlink($path);
+      $target = realpath($dir . '/' . $f);
+      if ($target !== false && strpos($target, $dir . DIRECTORY_SEPARATOR) === 0 && is_file($target)) {
+        unlink($target);
+      } else {
+        error_log('Invalid delete path: ' . $f);
+      }
     }
     header('Location: downloads.php?deleted=1');
     exit;

--- a/manage.php
+++ b/manage.php
@@ -17,9 +17,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
     // ファイル削除
     if (isset($_POST['delete']) && isset($_POST['filename'])) {
-        @unlink($uploadsDir . '/' . basename($_POST['filename']));
-        header('Location: manage.php?deleted=1');
-        exit;
+        $target = realpath($uploadsDir . '/' . $_POST['filename']);
+        if ($target !== false && strpos($target, $uploadsDir . DIRECTORY_SEPARATOR) === 0 && is_file($target)) {
+            unlink($target);
+            header('Location: manage.php?deleted=1');
+            exit;
+        } else {
+            error_log('Invalid delete path: ' . ($_POST['filename'] ?? ''));
+            http_response_code(400);
+            exit('Invalid file path');
+        }
     }
 }
 $history = [];


### PR DESCRIPTION
## Summary
- Use `realpath` and directory checks to validate deletion targets in manage and download scripts
- Log invalid delete requests instead of performing path traversal

## Testing
- `php -l manage.php`
- `php -l downloads.php`


------
https://chatgpt.com/codex/tasks/task_e_68b64dc8f0088331aa7edf72783cfb9a