### PR TITLE
Add HTML escaping helper and sanitize template output

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -1,5 +1,6 @@
 <?php
 session_start();
+require_once __DIR__ . '/includes/common.php';
 $dir = __DIR__ . '/downloads';
 $files = is_dir($dir) ? array_diff(scandir($dir), ['.', '..']) : [];
 
@@ -47,7 +48,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <main>
   <div class="card">
   <?php if (isset($_GET['done'])): ?>
-    <p style="color:green;"><?= htmlspecialchars($_GET['done'], ENT_QUOTES, 'UTF-8') ?> を保存しました。</p>
+    <p style="color:green;"><?= h($_GET['done']) ?> を保存しました。</p>
   <?php endif; ?>
     <?php if (isset($_GET['deleted'])): ?>
       <p style="color:green;">選択したファイルを削除しました。</p>
@@ -57,7 +58,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <p>まだ翻訳済みファイルがありません。</p>
     <?php else: ?>
       <form method="post">
-        <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+        <input type="hidden" name="csrf_token" value="<?= h($_SESSION['csrf_token'] ?? '') ?>">
         <table class="data-table">
           <thead>
             <tr>
@@ -69,10 +70,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
           <tbody>
           <?php foreach ($files as $f): ?>
             <tr>
-              <td><?= htmlspecialchars($f, ENT_QUOTES, 'UTF-8') ?></td>
-              <td><a href="downloads/<?= rawurlencode($f) ?>" download>ダウンロード</a></td>
+              <td><?= h($f) ?></td>
+              <td><a href="downloads/<?= h(rawurlencode($f)) ?>" download>ダウンロード</a></td>
               <td style="text-align:center">
-                <input type="checkbox" name="delete[]" value="<?= htmlspecialchars($f, ENT_QUOTES, 'UTF-8') ?>">
+                <input type="checkbox" name="delete[]" value="<?= h($f) ?>">
               </td>
             </tr>
           <?php endforeach; ?>

--- a/includes/common.php
+++ b/includes/common.php
@@ -1,0 +1,4 @@
+<?php
+function h($s) {
+    return htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+}

--- a/manage.php
+++ b/manage.php
@@ -1,6 +1,7 @@
 <?php
 session_start();
 require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/common.php';
 const RATE_JPY_PER_MILLION = 2500;
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
@@ -104,17 +105,17 @@ function cost_jpy(int $c): int {
         <?php
           $chars = $history[$f] ?? null;
           $charDisp = $chars ? number_format($chars) : '未計測';
-          $costDisp = $chars ? '&yen;' . number_format(cost_jpy($chars)) : '未計測';
+          $costDisp = $chars ? '¥' . number_format(cost_jpy($chars)) : '未計測';
         ?>
         <tr>
-          <td><?= htmlspecialchars($f) ?></td>
-          <td><?= $charDisp ?></td>
-          <td><?= $costDisp ?></td>
+          <td><?= h($f) ?></td>
+          <td><?= h($charDisp) ?></td>
+          <td><?= h($costDisp) ?></td>
           <td>
             <div class="inline-form-wrap">
               <!-- 翻訳再実行form -->
               <form method="post" action="translate.php">
-                <input type="hidden" name="filename" value="<?= htmlspecialchars($f, ENT_QUOTES, 'UTF-8') ?>">
+                <input type="hidden" name="filename" value="<?= h($f) ?>">
 
                 <select name="out_fmt">
                   <option value="pdf">PDF</option>
@@ -125,8 +126,8 @@ function cost_jpy(int $c): int {
               </form>
               <!-- 削除form（ボタンで即時削除） -->
               <form method="post" onsubmit="return confirm('本当に削除しますか？');">
-                <input type="hidden" name="filename" value="<?= htmlspecialchars($f, ENT_QUOTES, 'UTF-8') ?>">
-                <input type="hidden" name="csrf_token" value="<?= htmlspecialchars($_SESSION['csrf_token'] ?? '', ENT_QUOTES, 'UTF-8') ?>">
+                <input type="hidden" name="filename" value="<?= h($f) ?>">
+                <input type="hidden" name="csrf_token" value="<?= h($_SESSION['csrf_token'] ?? '') ?>">
                 <button type="submit" name="delete" value="1" style="color:red;">削除</button>
               </form>
             </div>

--- a/upload_file.php
+++ b/upload_file.php
@@ -1,5 +1,6 @@
 <?php
 require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/common.php';
 use Dotenv\Dotenv;
 use PhpOffice\PhpSpreadsheet\IOFactory;
 use Smalot\PdfParser\Parser;
@@ -145,7 +146,7 @@ function count_chars_local(string $path, string $ext): int|false {
   <main>
     <div class="card">
       <?php if ($step === 'upload'): ?>
-        <?php if ($message): ?><p class="error"><?= htmlspecialchars($message) ?></p><?php endif; ?>
+        <?php if ($message): ?><p class="error"><?= h($message) ?></p><?php endif; ?>
         <form method="post" enctype="multipart/form-data">
           <div class="file-input-wrapper">
             <input type="file" name="file" id="fileInput" style="display:none;" required>
@@ -159,14 +160,14 @@ function count_chars_local(string $path, string $ext): int|false {
 
       <?php else: ?>
         <h2>アップロード結果</h2>
-        <p>ファイル名: <?= htmlspecialchars($filename) ?></p>
-        <p>文字数：<?= number_format($rawChars) ?>字</p>
-        <p>概算コスト：￥<?= number_format($costJpy) ?></p>
+        <p>ファイル名: <?= h($filename) ?></p>
+        <p>文字数：<?= h(number_format($rawChars)) ?>字</p>
+        <p>概算コスト：￥<?= h(number_format($costJpy)) ?></p>
         <form action="translate.php" method="post">
-          <input type="hidden" name="filename" value="<?= htmlspecialchars($filename) ?>">
+          <input type="hidden" name="filename" value="<?= h($filename) ?>">
           <label for="out_fmt">変換形式：</label>
           <select name="out_fmt" id="out_fmt">
-            <?= $fmtOptions ?>
+            <?= $fmtOptions // pre-defined safe HTML ?>
           </select>
           <button type="submit">翻訳を開始</button>
         </form>


### PR DESCRIPTION
## Summary
- add common `h()` helper for HTML escaping
- escape dynamic variables in downloads, manage, and upload templates
- leave `$fmtOptions` as trusted predefined HTML

## Testing
- `php -l includes/common.php`
- `php -l manage.php`
- `php -l downloads.php`
- `php -l upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b64f380024833196bb4698e0c17097