### PR TITLE
Add sorting and pagination to file listings

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -2,11 +2,40 @@
 session_start();
 require_once __DIR__ . '/includes/common.php';
 $dir = __DIR__ . '/downloads';
-$files = is_dir($dir) ? array_diff(scandir($dir), ['.', '..']) : [];
+$allFiles = is_dir($dir) ? array_values(array_diff(scandir($dir), ['.', '..'])) : [];
 
 if ($_SERVER['REQUEST_METHOD'] === 'GET') {
   $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
 }
+
+$sort = $_GET['sort'] ?? 'name';
+$allowedSorts = ['name', 'mtime', 'size', 'ext'];
+if (!in_array($sort, $allowedSorts, true)) {
+  $sort = 'name';
+}
+
+usort($allFiles, function($a, $b) use ($sort, $dir) {
+  switch ($sort) {
+    case 'mtime':
+      return filemtime($dir . '/' . $b) <=> filemtime($dir . '/' . $a);
+    case 'size':
+      return filesize($dir . '/' . $b) <=> filesize($dir . '/' . $a);
+    case 'ext':
+      return strcasecmp(pathinfo($a, PATHINFO_EXTENSION), pathinfo($b, PATHINFO_EXTENSION));
+    default:
+      return strcasecmp($a, $b);
+  }
+});
+
+$limit = 10;
+$page = max(1, (int)($_GET['page'] ?? 1));
+$total = count($allFiles);
+$totalPages = (int)ceil($total / $limit);
+if ($totalPages > 0 && $page > $totalPages) {
+  $page = $totalPages;
+}
+$offset = ($page - 1) * $limit;
+$files = array_slice($allFiles, $offset, $limit);
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
@@ -54,9 +83,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
       <p style="color:green;">選択したファイルを削除しました。</p>
     <?php endif; ?>
 
-    <?php if (empty($files)): ?>
+    <?php if ($total === 0): ?>
       <p>まだ翻訳済みファイルがありません。</p>
     <?php else: ?>
+      <div class="sort-links">ソート: <a href="?sort=name">名前</a> | <a href="?sort=mtime">更新日時</a> | <a href="?sort=size">サイズ</a> | <a href="?sort=ext">拡張子</a></div>
       <form method="post">
         <input type="hidden" name="csrf_token" value="<?= h($_SESSION['csrf_token'] ?? '') ?>">
         <table class="data-table">
@@ -81,6 +111,17 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         </table>
         <button type="submit" class="action-btn">チェックしたファイルを削除</button>
       </form>
+      <?php if ($totalPages > 1): ?>
+        <div class="pagination">
+          <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+            <?php if ($i === $page): ?>
+              <strong><?= $i ?></strong>
+            <?php else: ?>
+              <a href="?sort=<?= h($sort) ?>&page=<?= $i ?>"><?= $i ?></a>
+            <?php endif; ?>
+          <?php endfor; ?>
+        </div>
+      <?php endif; ?>
     <?php endif; ?>
     <a href="index.html" class="back-link">トップへ戻る</a>
   </div>


### PR DESCRIPTION
## Summary
- Allow `manage.php` and `downloads.php` to accept `page` and `sort` query parameters
- Support sorting by name, modified time, file size, or extension and paginate results
- Render navigation links so users can browse between pages

## Testing
- `php -l manage.php`
- `php -l downloads.php`


------
https://chatgpt.com/codex/tasks/task_e_68b6513808188331bcbb457097a02c8b