### PR TITLE
Clean up history log on file deletion

### DIFF
--- a/manage.php
+++ b/manage.php
@@ -28,6 +28,27 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     unlink($translated);
                 }
             }
+            $historyFile = __DIR__ . '/logs/history.csv';
+            $rows = [];
+            if (file_exists($historyFile) && ($h = fopen($historyFile, 'r')) !== false) {
+                while (($row = fgetcsv($h)) !== false) {
+                    if (!isset($row[0]) || $row[0] !== $filename) {
+                        $rows[] = $row;
+                    }
+                }
+                fclose($h);
+            }
+            if (($h = fopen($historyFile, 'w')) !== false) {
+                foreach ($rows as $row) {
+                    if (fputcsv($h, $row) === false) {
+                        error_log('Failed to write history row for ' . $filename);
+                        break;
+                    }
+                }
+                fclose($h);
+            } else {
+                error_log('Failed to write history file: ' . $historyFile);
+            }
             header('Location: manage.php?deleted=1');
             exit;
         } else {


### PR DESCRIPTION
## Summary
- Remove deleted files from `logs/history.csv` during manage.php's delete handling
- Log errors if the history file cannot be written

## Testing
- `php -l manage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b66b0db03c8331b87ab3e32b8e074b