### PR TITLE
Track total translation cost

### DIFF
--- a/manage.php
+++ b/manage.php
@@ -60,6 +60,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 }
 $history = [];
 $totalChars = 0;
+$totalCost = 0;
 if (($h = fopen(__DIR__ . '/logs/history.csv', 'r'))) {
     while (($row = fgetcsv($h)) !== false) {
         if (count($row) < 2) continue;
@@ -67,6 +68,7 @@ if (($h = fopen(__DIR__ . '/logs/history.csv', 'r'))) {
         $chars = (int)$chars;
         $history[$fn] = $chars;
         $totalChars += $chars;
+        $totalCost += cost_jpy($chars);
     }
     fclose($h);
 }
@@ -199,7 +201,7 @@ function cost_jpy(int $c): int {
       <tr class="summary-row">
         <td>合計</td>
         <td><?= h(number_format($totalChars)) ?></td>
-        <td><?= h('¥' . number_format(cost_jpy($totalChars))) ?></td>
+        <td><?= h('¥' . number_format($totalCost)) ?></td>
         <td></td>
       </tr>
       </tbody>


### PR DESCRIPTION
## Summary
- accumulate per-file translation charges while reading history
- display summed cost in the file summary row

## Testing
- `php -l manage.php`
- `php -r 'function cost_jpy($c){return (int)round(max(50000,$c)/1_000_000*2500);} $cost1=cost_jpy(100); $cost2=cost_jpy(100); $total=$cost1+$cost2; $aggregate=cost_jpy(200); echo "cost1=$cost1 cost2=$cost2 total=$total aggregate=$aggregate\n";'`


------
https://chatgpt.com/codex/tasks/task_e_68b66fc03a548331b995e6fc748e08be