### PR TITLE
Add translation progress tracking and status endpoint

### DIFF
--- a/progress.php
+++ b/progress.php
@@ -1,0 +1,13 @@
+<?php
+session_start();
+header('Content-Type: application/json');
+$progressFile = sys_get_temp_dir() . '/progress_' . session_id() . '.json';
+if (is_file($progressFile)) {
+    $data = json_decode(file_get_contents($progressFile), true);
+    if (!is_array($data)) {
+        $data = ['percent'=>0, 'message'=>''];
+    }
+} else {
+    $data = ['percent'=>0, 'message'=>''];
+}
+echo json_encode($data);


### PR DESCRIPTION
## Summary
- track translation steps in a session-scoped progress file and clean it up on completion
- report progress during text, spreadsheet, and document translations, including API polling and file generation
- provide `progress.php` endpoint to return current percentage and message for polling

## Testing
- `php -l translate.php`
- `php -l progress.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7930f5c408331bb656fac21c2145a