### PR TITLE
Handle missing DeepL API key gracefully

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -11,8 +11,18 @@ use PhpOffice\PhpSpreadsheet\IOFactory as SpreadsheetIOFactory;
 
 /* DeepL APIキー読み込み */
 $dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
-$dotenv->load();
-define('DEEPL_KEY', $_ENV['DEEPL_AUTH_KEY'] ?? '');
+$apiKey = '';
+if (file_exists(__DIR__ . '/.env')) {
+    $dotenv->load();
+    $apiKey = $_ENV['DEEPL_AUTH_KEY'] ?? '';
+} else {
+    $apiKey = getenv('DEEPL_AUTH_KEY') ?: '';
+}
+if ($apiKey === '') {
+    http_response_code(500);
+    die('DeepL APIキーが未設定です');
+}
+define('DEEPL_KEY', $apiKey);
 
 /* パラメータ取得 */
 $filename = $_POST['filename'] ?? '';


### PR DESCRIPTION
## Summary
- Load DeepL API key from `.env` only if the file exists, fallback to environment variable otherwise
- Abort with HTTP 500 and message when API key is absent

## Testing
- `php -l translate.php`


------
https://chatgpt.com/codex/tasks/task_e_68b79e781f5483319f48a355e76dcac1