### PR TITLE
Add DeepL API key configuration check

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -18,11 +18,12 @@ if (file_exists(__DIR__ . '/.env')) {
 } else {
     $apiKey = getenv('DEEPL_AUTH_KEY') ?: '';
 }
-if ($apiKey === '') {
-    http_response_code(500);
-    die('DeepL APIキーが未設定です');
-}
 define('DEEPL_KEY', $apiKey);
+if (empty(DEEPL_KEY)) {
+    http_response_code(400);
+    echo 'DeepL APIキーが設定されていません';
+    exit;
+}
 
 /* パラメータ取得 */
 $filename = $_POST['filename'] ?? '';


### PR DESCRIPTION
## Summary
- exit with HTTP 400 when `DEEPL_KEY` is empty so users know to set DeepL API key

## Testing
- `php -l translate.php`


------
https://chatgpt.com/codex/tasks/task_e_68b79f25541c83318775aac0e6ec4974