### PR TITLE
Start PHP session early in uploads

### DIFF
--- a/upload_file.php
+++ b/upload_file.php
@@ -1,4 +1,5 @@
 <?php
+session_start();
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/common.php';
 use Dotenv\Dotenv;


### PR DESCRIPTION
## Summary
- call `session_start()` at the top of `upload_file.php` so the session cookie is sent before Ajax requests

## Testing
- `php -l upload_file.php`
- `composer validate --no-check-all --no-check-lock`


------
https://chatgpt.com/codex/tasks/task_e_68b7a2b8074083319d0302266b42fd2f