### PR TITLE
Release session lock before translation processing

### DIFF
--- a/progress.php
+++ b/progress.php
@@ -1,7 +1,9 @@
 <?php
 session_start();
+$sid = session_id();
+session_write_close();
 header('Content-Type: application/json');
-$progressFile = sys_get_temp_dir() . '/progress_' . session_id() . '.json';
+$progressFile = sys_get_temp_dir() . '/progress_' . $sid . '.json';
 if (is_file($progressFile)) {
     $data = json_decode(file_get_contents($progressFile), true);
     if (!is_array($data)) {

--- a/translate.php
+++ b/translate.php
@@ -1,5 +1,7 @@
 <?php
 session_start();
+$sid = session_id();
+session_write_close();
 require_once __DIR__ . '/vendor/autoload.php';
 
 use Mpdf\Mpdf;
@@ -42,7 +44,7 @@ if (!is_dir($dlDir) && !mkdir($dlDir, 0755, true)) {
     die('ダウンロードディレクトリの作成に失敗しました');
 }
 
-$progressFile = sys_get_temp_dir() . '/progress_' . session_id() . '.json';
+$progressFile = sys_get_temp_dir() . '/progress_' . $sid . '.json';
 $updateProgress = function(int $percent, string $message) use ($progressFile) {
     file_put_contents($progressFile, json_encode(['percent'=>$percent, 'message'=>$message]));
 };


### PR DESCRIPTION
## Summary
- Close session in progress tracker before reading progress file
- Release session lock early in translation script prior to heavy processing

## Testing
- `php -l progress.php`
- `php -l translate.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7a33e35448331a4aa61e584e89ec2