### PR TITLE
Ensure session cookies for fetch requests

### DIFF
--- a/manage.php
+++ b/manage.php
@@ -253,7 +253,7 @@ document.addEventListener('DOMContentLoaded', function(){
       updateSpinner(0, '翻訳を開始しています');
       const fd = new FormData(form);
       const timer = setInterval(() => {
-        fetch('progress.php')
+        fetch('progress.php', { credentials: 'same-origin' })
           .then(r => r.json())
           .then(d => {
             updateSpinner(d.percent, d.message);
@@ -264,7 +264,7 @@ document.addEventListener('DOMContentLoaded', function(){
           .catch(() => {});
       }, 1000);
 
-      fetch('translate.php', {method: 'POST', body: fd})
+        fetch('translate.php', {method: 'POST', body: fd, credentials: 'same-origin'})
         .then(res => {
           if (!res.ok) throw new Error('翻訳に失敗しました');
           return res;

--- a/upload_file.php
+++ b/upload_file.php
@@ -196,7 +196,7 @@ function count_chars_local(string $path, string $ext): int|false {
         updateSpinner(0, '翻訳を開始しています');
         const fd = new FormData(form);
         const timer = setInterval(() => {
-          fetch('progress.php')
+          fetch('progress.php', { credentials: 'same-origin' })
             .then(r => r.json())
             .then(d => {
               updateSpinner(d.percent, d.message);
@@ -207,7 +207,7 @@ function count_chars_local(string $path, string $ext): int|false {
             .catch(() => {});
         }, 1000);
 
-        fetch('translate.php', {method: 'POST', body: fd})
+        fetch('translate.php', {method: 'POST', body: fd, credentials: 'same-origin'})
           .then(res => {
             if (!res.ok) throw new Error('翻訳に失敗しました');
             return res;


### PR DESCRIPTION
## Summary
- include credentials in progress and translate fetches so session cookies accompany requests

## Testing
- `php -l upload_file.php`
- `php -l manage.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7a9f5996c833190c1a1164a9f2ded