### PR TITLE
Display default translation progress message

### DIFF
--- a/progress.php
+++ b/progress.php
@@ -10,6 +10,6 @@ if (is_file($progressFile)) {
         $data = ['percent'=>0, 'message'=>''];
     }
 } else {
-    $data = ['percent'=>0, 'message'=>''];
+    $data = ['percent'=>0, 'message'=>'翻訳実行中……'];
 }
 echo json_encode($data);

--- a/upload_file.php
+++ b/upload_file.php
@@ -193,7 +193,7 @@ function count_chars_local(string $path, string $ext): int|false {
       form.addEventListener('submit', function(e){
         e.preventDefault();
         showSpinner();
-        updateSpinner(0, '翻訳を開始しています');
+        updateSpinner(0, '翻訳実行中……');
         const fd = new FormData(form);
         const timer = setInterval(() => {
           fetch('progress.php', { credentials: 'same-origin' })


### PR DESCRIPTION
## Summary
- Add default progress message '翻訳実行中……' when progress file missing
- Initialize spinner with same message when translation begins

## Testing
- `php -l progress.php`
- `php -l upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7b1909a588331ae266e1085bab3f8