### PR TITLE
Handle unsupported conversions and surface server errors

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -60,7 +60,9 @@ $updateProgress(10, 'ドキュメントをアップロード中');
 ====================================================================*/
 if ($ext === 'txt') {
     if ($fmt === 'xlsx') {
-        die('TXT入力はPDFまたはDOCXのみ出力可能です。');
+        http_response_code(400);
+        echo 'TXT入力はPDFまたはDOCXのみ出力可能です。';
+        exit;
     }
     $plain = file_get_contents($src);
     if ($plain === false) {
@@ -151,7 +153,9 @@ if ($ext === 'txt') {
 ====================================================================*/
 if ($ext === 'xlsx') {
     if ($fmt !== 'xlsx') {
-        die('DeepL API仕様上、XLSX→他形式はサポートされていません。XLSXでのみ出力可能です。');
+        http_response_code(400);
+        echo 'DeepL API仕様上、XLSX→他形式はサポートされていません。XLSXでのみ出力可能です。';
+        exit;
     }
     // DeepL Text API helper: send array of texts with exponential backoff retry
     $deepl = function(array $texts) {
@@ -276,7 +280,9 @@ if ($ext === 'xlsx') {
 ====================================================================*/
 // DeepL API: PDFアップロード時はPDFまたはDOCXが出力可能
 if ($ext === 'pdf' && $fmt === 'xlsx') {
-    die('DeepL API仕様上、PDF→XLSXはサポートされていません。');
+    http_response_code(400);
+    echo 'DeepL API仕様上、PDF→XLSXはサポートされていません。';
+    exit;
 }
 
 $up = curl_init('https://api.deepl.com/v2/document');

--- a/upload_file.php
+++ b/upload_file.php
@@ -209,15 +209,14 @@ function count_chars_local(string $path, string $ext): int|false {
 
         fetch('translate.php', {method: 'POST', body: fd, credentials: 'same-origin'})
           .then(res => {
-            if (!res.ok) throw new Error('翻訳に失敗しました');
-            return res;
-          })
-          .then(res => {
             clearInterval(timer);
-            if (res.redirected) {
+            if (res.redirected && res.ok) {
               window.location.href = res.url;
             } else {
-              hideSpinner();
+              return res.text().then(msg => {
+                alert(msg || '翻訳に失敗しました');
+                hideSpinner();
+              });
             }
           })
           .catch(err => {


### PR DESCRIPTION
## Summary
- Return HTTP 400 with error message instead of die() for unsupported conversion combinations
- Show server-provided error messages in upload workflow when translation doesn't redirect or fails

## Testing
- `php -l translate.php`
- `php -l upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7b22e1b508331b6e81dde0699d1f7