### PR TITLE
Add spinner overlay with progress text

### DIFF
--- a/includes/spinner.php
+++ b/includes/spinner.php
@@ -1,4 +1,4 @@
-<div id="spinner" class="spinner-overlay" style="display:none;">
+<div id="spinner" class="spinner-overlay">
   <div class="spinner"></div>
   <div id="progress-bar"></div>
   <span id="progress-text"></span>

--- a/manage.php
+++ b/manage.php
@@ -250,7 +250,7 @@ document.addEventListener('DOMContentLoaded', function(){
     form.addEventListener('submit', function(e){
       e.preventDefault();
       showSpinner();
-      updateSpinner(0, '翻訳を開始しています');
+      updateSpinner(0, '翻訳実行中…');
       const fd = new FormData(form);
       const timer = setInterval(() => {
         fetch('progress.php', { credentials: 'same-origin' })

--- a/spinner.js
+++ b/spinner.js
@@ -1,6 +1,9 @@
-function showSpinner() {
+function showSpinner(message) {
   var s = document.getElementById('spinner');
-  if (s) s.style.display = 'flex';
+  if (s) {
+    s.style.display = 'flex';
+    updateSpinner(0, message || '翻訳実行中…');
+  }
 }
 function hideSpinner() {
   var s = document.getElementById('spinner');

--- a/style.css
+++ b/style.css
@@ -121,6 +121,36 @@ footer {
   line-height:40px;
 }
 
+/* ---------- Spinner Overlay ---------- */
+.spinner-overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100vw;
+  height: 100vh;
+  background: rgba(0, 0, 0, 0.5);
+  display: none;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  z-index: 9999;
+  color: #fff;
+}
+
+.spinner {
+  width: 60px;
+  height: 60px;
+  border: 6px solid rgba(255, 255, 255, 0.3);
+  border-top-color: #fff;
+  border-radius: 50%;
+  animation: spin 1s linear infinite;
+  margin-bottom: 15px;
+}
+
+@keyframes spin {
+  to { transform: rotate(360deg); }
+}
+
 /* ---------- Spinner Progress ---------- */
 #progress-bar {
   width: 0;

--- a/upload_file.php
+++ b/upload_file.php
@@ -193,7 +193,7 @@ function count_chars_local(string $path, string $ext): int|false {
       form.addEventListener('submit', function(e){
         e.preventDefault();
         showSpinner();
-        updateSpinner(0, '翻訳実行中……');
+        updateSpinner(0, '翻訳実行中…');
         const fd = new FormData(form);
         const timer = setInterval(() => {
           fetch('progress.php', { credentials: 'same-origin' })


### PR DESCRIPTION
## Summary
- style spinner overlay and spinner animation
- show spinner with default "翻訳実行中…" progress text
- use new spinner overlay for uploads and bulk translate actions

## Testing
- `php -l includes/spinner.php`
- `php -l upload_file.php`
- `php -l manage.php`
- `node --check spinner.js && echo "syntax ok"`


------
https://chatgpt.com/codex/tasks/task_e_68b7b90fa11c8331b1740af8e307b8d5