### PR TITLE
feat: add output format selection

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -21,6 +21,7 @@ if ($apiKey === '' || $apiBase === '') {
 }
 
 $filename = $_POST['filename'] ?? '';
+$outputFormat = $_POST['output_format'] ?? '';
 $src = __DIR__ . '/uploads/' . basename($filename);
 if ($filename === '' || !is_file($src)) {
     http_response_code(400);
@@ -149,7 +150,9 @@ if (!is_dir($outDir) && !mkdir($outDir, 0777, true)) {
     echo '出力ディレクトリの作成に失敗しました';
     exit;
 }
-$outExt = ($ext === 'pdf') ? 'pdf' : 'docx';
+$outExt = ($ext === 'pdf')
+    ? (in_array($outputFormat, ['pdf', 'docx'], true) ? $outputFormat : 'pdf')
+    : 'docx';
 $outName = pathinfo($filename, PATHINFO_FILENAME) . '-ja.' . $outExt;
 $outPath = $outDir . '/' . $outName;
 if (file_put_contents($outPath, $fileData) === false) {

--- a/upload_file.php
+++ b/upload_file.php
@@ -14,6 +14,7 @@ $step = 'upload';
 $message = '';
 $filename = '';
 $ext = '';
+$outputFormat = $_POST['output_format'] ?? '';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     if (isset($_FILES['file']) && is_uploaded_file($_FILES['file']['tmp_name'])) {
@@ -90,6 +91,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <p>ファイル名: <?= h($filename) ?></p>
         <form id="translateForm" action="translate.php" method="post">
           <input type="hidden" name="filename" value="<?= h($filename) ?>">
+          <label for="output_format">出力形式（PDFアップ時のみDOCX可）</label>
+          <select name="output_format" id="output_format">
+            <option value="" <?= $outputFormat === '' ? 'selected' : '' ?>></option>
+            <option value="pdf" <?= $outputFormat === 'pdf' ? 'selected' : '' ?>>pdf</option>
+            <option value="docx" <?= $outputFormat === 'docx' ? 'selected' : '' ?>>docx</option>
+          </select>
           <button type="submit">翻訳を開始</button>
         </form>
       <?php endif; ?>


### PR DESCRIPTION
## Summary
- add output format selector to confirmation step
- use selected format when saving translated file

## Testing
- `php -l upload_file.php`
- `php -l translate.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7e3b95df4833182bf73c8654cc056