### PR TITLE
Log missing DeepL env vars

### DIFF
--- a/translate.php
+++ b/translate.php
@@ -16,7 +16,15 @@ $apiKey  = $_ENV['DEEPL_API_KEY']  ?? getenv('DEEPL_API_KEY')  ?? '';
 $apiBase = rtrim($_ENV['DEEPL_API_BASE'] ?? getenv('DEEPL_API_BASE') ?? '', '/');
 $price   = (float)($_ENV['DEEPL_PRICE_PER_MILLION'] ?? getenv('DEEPL_PRICE_PER_MILLION') ?? 25);
 $priceCcy = $_ENV['DEEPL_PRICE_CCY'] ?? getenv('DEEPL_PRICE_CCY') ?? 'USD';
-if ($apiKey === '' || $apiBase === '') {
+$missing = [];
+if ($apiKey === '') {
+    $missing[] = 'DEEPL_API_KEY';
+}
+if ($apiBase === '') {
+    $missing[] = 'DEEPL_API_BASE';
+}
+if ($missing) {
+    error_log('[DeepL] missing env vars: ' . implode(', ', $missing));
     http_response_code(500);
     echo 'DeepL API設定が不足しています';
     exit;

--- a/upload_file.php
+++ b/upload_file.php
@@ -3,6 +3,27 @@ session_start();
 require_once __DIR__ . '/vendor/autoload.php';
 require_once __DIR__ . '/includes/common.php';
 
+use Dotenv\Dotenv;
+
+$dotenv = Dotenv::createImmutable(__DIR__);
+if (file_exists(__DIR__ . '/.env')) {
+    $dotenv->load();
+}
+$apiKey  = $_ENV['DEEPL_API_KEY']  ?? getenv('DEEPL_API_KEY')  ?? '';
+$apiBase = rtrim($_ENV['DEEPL_API_BASE'] ?? getenv('DEEPL_API_BASE') ?? '', '/');
+$missing = [];
+if ($apiKey === '') {
+    $missing[] = 'DEEPL_API_KEY';
+}
+if ($apiBase === '') {
+    $missing[] = 'DEEPL_API_BASE';
+}
+if ($missing) {
+    error_log('[DeepL] missing env vars: ' . implode(', ', $missing));
+    http_response_code(500);
+    die('DeepL API設定が不足しています');
+}
+
 $uploadsDir = __DIR__ . '/uploads';
 if (!is_dir($uploadsDir) && !mkdir($uploadsDir, 0777, true)) {
     error_log("Failed to create uploads directory: $uploadsDir");


### PR DESCRIPTION
## Summary
- log missing DeepL env vars and show user error in translate.php
- mirror env var presence check in upload_file.php

## Testing
- `php -l translate.php`
- `php -l upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b7e73a80208331a58701e62f2e59c9