### PR TITLE
Support TXT uploads and improve PDF character estimation

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -53,6 +53,12 @@ function estimate_chars(string $path, string $ext): array {
         } else {
             error_log('PDF text extraction failed for ' . $path);
         }
+    } elseif ($ext === 'txt') {
+        $content = @file_get_contents($path);
+        if ($content !== false) {
+            $chars = mb_strlen($content);
+            $detail = 'txt';
+        }
     } elseif (in_array($ext, ['docx', 'pptx', 'xlsx'], true)) {
         $zip = new ZipArchive();
         if ($zip->open($path) === true) {


### PR DESCRIPTION
## Summary
- allow uploading and translating `.txt` files
- handle text files via DeepL text API with character counting
- improve PDF upload handling when text extraction fails

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b81f903cb48331ac8cf2782e6f9d7e