### PR TITLE
Gracefully handle PDF extraction failures

### DIFF
--- a/includes/common.php
+++ b/includes/common.php
@@ -34,6 +34,13 @@ function estimate_chars(string $path, string $ext): array {
     $detail = '';
 
     if ($ext === 'pdf') {
+        $pdftotextCmd = trim((string) @shell_exec('command -v pdftotext'));
+        $qpdfCmd      = trim((string) @shell_exec('command -v qpdf'));
+        if ($pdftotextCmd === '' || $qpdfCmd === '') {
+            error_log('pdftotext or qpdf not available');
+            return [$chars, 'pdf_failed'];
+        }
+
         $detail = 'pdf';
         $cmd = sprintf('pdftotext -q %s - 2>/dev/null', escapeshellarg($path));
         $text = shell_exec($cmd);
@@ -52,6 +59,7 @@ function estimate_chars(string $path, string $ext): array {
             $chars = mb_strlen($text);
         } else {
             error_log('PDF text extraction failed for ' . $path);
+            return [$chars, 'pdf_failed'];
         }
     } elseif ($ext === 'txt') {
         $content = @file_get_contents($path);

--- a/upload_file.php
+++ b/upload_file.php
@@ -40,6 +40,7 @@ if (!is_dir($uploadsDir) && !mkdir($uploadsDir, 0777, true)) {
 
 $step = 'upload';
 $message = '';
+$warning = '';
 $filename = '';
 $ext = '';
 $outputFormat = $_POST['output_format'] ?? '';
@@ -66,8 +67,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $message = '30MBを超えています';
             } else {
                 [$estChars, $detail] = estimate_chars($dest, $ext);
-                if ($detail === 'pdf' && $estChars === 0) {
-                    $message = 'PDFのテキスト抽出に失敗しました。スキャンPDFなどは非対応です。';
+                if ($detail === 'pdf_failed') {
+                    $warning = 'PDFの文字数を推定できませんでした。スキャンPDFなどは翻訳できない可能性があります。';
                 }
                 if ($message === '') {
                     $logDir = __DIR__ . '/logs';
@@ -91,7 +92,10 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                             fclose($fh);
                         }
                     }
-                    $displayChars = max(50000, $estChars);
+                    $displayChars = $estChars;
+                    if ($detail === 'pdf_failed') {
+                        $displayChars = max(50000, $displayChars);
+                    }
                     $charDisp = number_format($displayChars);
                     if ($displayChars !== $estChars) {
                         $charDisp .= ' (' . number_format($estChars) . ')';
@@ -118,6 +122,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     aside { float: left; width: 200px; }
     main { margin-left: 220px; }
     .error { color: red; }
+    .warning { color: #d90; }
     .file-input-wrapper { margin-bottom: 10px; }
     #selectedFileName { margin: 6px 0; color: #333; }
   </style>
@@ -140,6 +145,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
   <main>
     <div class="card">
       <?php if ($message): ?><p class="error"><?= h($message) ?></p><?php endif; ?>
+      <?php if ($warning): ?><p class="warning"><?= h($warning) ?></p><?php endif; ?>
       <?php if ($step === 'upload'): ?>
         <form method="post" enctype="multipart/form-data">
           <div class="file-input-wrapper">


### PR DESCRIPTION
## Summary
- Detect missing `pdftotext`/`qpdf` utilities and return a `pdf_failed` sentinel from `estimate_chars`
- Allow uploads to proceed when PDF text extraction fails and show a warning instead of blocking
- Provide fallback cost estimate when PDF character count is unknown

## Testing
- `php -l includes/common.php`
- `php -l upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b823bce048833196f71cd9c52f1bbb