### PR TITLE
docs: mention optional PDF text estimation tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ DeepL Translation Tool (PHP)
 - **PHP 8.x**
 - **Composer**
 - **php-zip**（DOCX出力に必須。例: `sudo apt install php8.2-zip`）
+- **pdftotext** と **qpdf**（PDF文字数見積もりのみに使用。コスト見積もりを行わない場合は不要。例: `apt install poppler-utils qpdf`）
 - 以下の Composer パッケージ
     - [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv)
     - [`mpdf/mpdf`](https://github.com/mpdf/mpdf)


### PR DESCRIPTION
## Summary
- document optional use of pdftotext and qpdf for PDF text estimation

## Testing
- `composer validate` *(fails: Lock file is not up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68b825ddd39c83319f61859d709e1f72