### PR TITLE
feat: add OCR fallback for PDF estimation

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ DeepL Translation Tool (PHP)
 - **Composer**
 - **php-zip**（DOCX出力に必須。例: `sudo apt install php8.2-zip`）
 - **pdftotext** と **qpdf**（PDF文字数見積もりのみに使用。コスト見積もりを行わない場合は不要。例: `apt install poppler-utils qpdf`）
+- **ocrmypdf** と **tesseract-ocr**（オプション。標準のテキスト抽出が失敗したPDFにOCRを適用する場合に使用。例: `apt install ocrmypdf tesseract-ocr`）
 - 以下の Composer パッケージ
     - [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv)
     - [`mpdf/mpdf`](https://github.com/mpdf/mpdf)
@@ -36,7 +37,15 @@ DeepL Translation Tool (PHP)
 
     `php -m | grep zip` で `zip` が表示されればOKです。
 
-3. **.envファイルの作成とAPI設定**
+3. **OCRツールのインストール（オプション）**
+
+    ```bash
+    sudo apt install ocrmypdf tesseract-ocr
+    ```
+
+    PDFのテキスト抽出が失敗した場合にOCRを試みるために使用します。
+
+4. **.envファイルの作成とAPI設定**
 
     プロジェクトルート直下に`.env`ファイルを作成し、下記のように記述します（実際の値に置き換えてください）。
 
@@ -48,7 +57,7 @@ DeepL Translation Tool (PHP)
     - `DEEPL_API_KEY` : DeepLの認証キー。
     - `DEEPL_API_BASE` : Document API のエンドポイント。Proプランの場合は `https://api.deepl.com/v2` を指定します。
 
-4. **.envファイルのセキュリティ対策**
+5. **.envファイルのセキュリティ対策**
 
     `.env` ファイルはWebからのアクセスを禁止してください。  
     プロジェクトルート直下に**.htaccess**を作成し、以下の内容を記載します。
@@ -61,7 +70,7 @@ DeepL Translation Tool (PHP)
 
     `.env` のパーミッションは `-r--------`（所有者のみ読み取り可）としてください。
 
-5. **フォントの配置（日本語PDF出力用）**
+6. **フォントの配置（日本語PDF出力用）**
 
     - `fonts` ディレクトリを作成し、`ipaexg.ttf` など日本語対応TrueTypeフォントを配置してください。
 


### PR DESCRIPTION
## Summary
- try `ocrmypdf` when pdftotext/qpdf extraction fails for PDFs
- document optional OCR dependency and how to install it

## Testing
- `php -l includes/common.php`
- `composer validate` *(fails: lock file is not up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68b8266800708331bb2ef739e47fce06