### PR TITLE
feat: add tesseract check and clarify OCR fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ DeepL Translation Tool (PHP)
 - **Composer**
 - **php-zip**（DOCX出力に必須。例: `sudo apt install php8.2-zip`）
 - **pdftotext** と **qpdf**（PDF文字数見積もりのみに使用。コスト見積もりを行わない場合は不要。例: `apt install poppler-utils qpdf`）
-- **ocrmypdf** と **tesseract-ocr**（オプション。標準のテキスト抽出が失敗したPDFにOCRを適用する場合に使用。例: `apt install ocrmypdf tesseract-ocr`）
+- **ocrmypdf** と **tesseract-ocr**（オプション。標準のテキスト抽出が空だったPDFに自動でOCRを適用するために使用。例: `apt install ocrmypdf tesseract-ocr`）
 - 以下の Composer パッケージ
     - [`vlucas/phpdotenv`](https://github.com/vlucas/phpdotenv)
     - [`mpdf/mpdf`](https://github.com/mpdf/mpdf)
@@ -43,7 +43,7 @@ DeepL Translation Tool (PHP)
     sudo apt install ocrmypdf tesseract-ocr
     ```
 
-    PDFのテキスト抽出が失敗した場合にOCRを試みるために使用します。
+    標準のテキスト抽出が空だったPDFに自動でOCRを適用します。両方のコマンドが見つからない場合は処理をスキップします。
 
 4. **.envファイルの作成とAPI設定**
 

--- a/includes/common.php
+++ b/includes/common.php
@@ -44,7 +44,7 @@ function estimate_chars(string $path, string $ext): array {
         $detail = 'pdf';
         $cmd = sprintf('pdftotext -q %s - 2>/dev/null', escapeshellarg($path));
         $text = shell_exec($cmd);
-        if (!is_string($text) || $text === '') {
+        if (!is_string($text) || trim((string) $text) === '') {
             $tmp = tempnam(sys_get_temp_dir(), 'pdf');
             $cmd = sprintf(
                 'qpdf --decrypt %s %s 2>/dev/null && pdftotext -q %s - 2>/dev/null',
@@ -55,11 +55,12 @@ function estimate_chars(string $path, string $ext): array {
             $text = shell_exec($cmd);
             @unlink($tmp);
         }
-        if (is_string($text) && $text !== '') {
+        if (is_string($text) && trim($text) !== '') {
             $chars = mb_strlen($text);
         } else {
             $ocrmypdfCmd = trim((string) @shell_exec('command -v ocrmypdf'));
-            if ($ocrmypdfCmd !== '') {
+            $tesseractCmd = trim((string) @shell_exec('command -v tesseract'));
+            if ($ocrmypdfCmd !== '' && $tesseractCmd !== '') {
                 $tmpPdf = tempnam(sys_get_temp_dir(), 'ocr');
                 $tmpTxt = tempnam(sys_get_temp_dir(), 'ocr');
                 $cmd = sprintf(
@@ -72,7 +73,7 @@ function estimate_chars(string $path, string $ext): array {
                 $ocrText = @file_get_contents($tmpTxt);
                 @unlink($tmpPdf);
                 @unlink($tmpTxt);
-                if (is_string($ocrText) && $ocrText !== '') {
+                if (is_string($ocrText) && trim($ocrText) !== '') {
                     $chars = mb_strlen($ocrText);
                     $detail = 'pdf_ocr';
                 } else {


### PR DESCRIPTION
## Summary
- run OCR with ocrmypdf and tesseract when pdftotext yields no content
- clarify optional OCR dependency in README

## Testing
- `php -l includes/common.php`
- `php -l upload_file.php`


------
https://chatgpt.com/codex/tasks/task_e_68b827e8de008331b506cc2f8fe463d1