### PR TITLE
Add smalot/pdfparser dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -7,7 +7,8 @@
         "vlucas/phpdotenv": "^5.5",
         "mpdf/mpdf": "^8.2",
         "phpoffice/phpword": "^1.1",
-        "phpoffice/phpspreadsheet": "^1.29"
+        "phpoffice/phpspreadsheet": "^1.29",
+        "smalot/pdfparser": "^0.16"
     },
     "minimum-stability": "stable",
     "license": "MIT"


### PR DESCRIPTION
## Summary
- add smalot/pdfparser requirement to composer.json

## Testing
- `composer update smalot/pdfparser` *(fails: curl error 56 CONNECT tunnel failed, response 403)*
- `php -r "require 'vendor/autoload.php'; new Smalot\\PdfParser\\Parser();"` *(fails: Failed opening required 'vendor/autoload.php')*


------
https://chatgpt.com/codex/tasks/task_e_68b834765244833188b60ac92174af3b