### PR TITLE
Add progress polling spinner on file translation

### DIFF
--- a/spinner.js
+++ b/spinner.js
@@ -1,25 +1,31 @@
-function showSpinner(message) {
-  var s = document.getElementById('spinner');
-  if (s) {
-    s.style.display = 'flex';
-    updateSpinner(0, message || '翻訳実行中…');
+(function (global) {
+  function showSpinner(message) {
+    const s = document.getElementById('spinner');
+    if (s) {
+      s.style.display = 'flex';
+      updateSpinner(0, message || '翻訳実行中…');
+    }
   }
-}
-function hideSpinner() {
-  var s = document.getElementById('spinner');
-  if (s) s.style.display = 'none';
-}
-function updateSpinner(progress, message) {
-  var bar = document.getElementById('progress-bar');
-  var text = document.getElementById('progress-text');
-  if (bar) bar.style.width = progress + '%';
-  if (text) {
-    var msg = message || '';
-    text.textContent = msg + (msg ? ' ' : '') + progress + '%';
-  }
-}
-document.addEventListener('DOMContentLoaded', hideSpinner);
 
-window.showSpinner = showSpinner;
-window.hideSpinner = hideSpinner;
-window.updateSpinner = updateSpinner;
+  function hideSpinner() {
+    const s = document.getElementById('spinner');
+    if (s) s.style.display = 'none';
+  }
+
+  function updateSpinner(progress, message) {
+    const bar = document.getElementById('progress-bar');
+    const text = document.getElementById('progress-text');
+    if (bar) bar.style.width = progress + '%';
+    if (text) {
+      const msg = message || '';
+      text.textContent = msg + (msg ? ' ' : '') + progress + '%';
+    }
+  }
+
+  document.addEventListener('DOMContentLoaded', hideSpinner);
+
+  global.showSpinner = showSpinner;
+  global.updateSpinner = updateSpinner;
+  global.hideSpinner = hideSpinner;
+})(window);
+

--- a/upload_file.php
+++ b/upload_file.php
@@ -179,9 +179,8 @@ function count_chars_local(string $path): int|false {
       form.addEventListener('submit', function(e){
         e.preventDefault();
         showSpinner();
-        updateSpinner(0, '翻訳実行中…');
         const fd = new FormData(form);
-        const timer = setInterval(() => {
+        const poll = () => {
           fetch('progress.php', { credentials: 'same-origin' })
             .then(r => r.json())
             .then(d => {
@@ -191,7 +190,9 @@ function count_chars_local(string $path): int|false {
               }
             })
             .catch(() => {});
-        }, 1000);
+        };
+        poll();
+        const timer = setInterval(poll, 1000);
 
         fetch('translate.php', {method: 'POST', body: fd, credentials: 'same-origin'})
           .then(res => {


### PR DESCRIPTION
## Summary
- poll progress.php every second to update a progress spinner during translation
- expose showSpinner, updateSpinner, and hideSpinner globals

## Testing
- `php -l upload_file.php`
- `node --check spinner.js`


------
https://chatgpt.com/codex/tasks/task_e_68b835e111348331ba96157746d57093