### PR TITLE
Add glossary ID environment support and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,11 +69,14 @@ DeepL Translation Tool (PHP)
     DEEPL_API_BASE=https://api-free.deepl.com/v2
     # 任意: デバッグログ（機微はマスク）
     APP_DEBUG=false
+    # 任意: デフォルト用語集ID
+    DEEPL_GLOSSARY_ID=xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx
     ```
 
     - `DEEPL_API_KEY` / `DEEPL_AUTH_KEY` : DeepLの認証キー（両対応、非空な方を使用）。
     - `DEEPL_API_BASE` : Document API のエンドポイント。Proプランの場合は `https://api.deepl.com/v2` を指定します。
     - `APP_DEBUG` : true で詳細デバッグログを出力。
+    - `DEEPL_GLOSSARY_ID` : 未指定時に自動で使用する用語集ID（フォームで指定した値が優先されます）。
 
 6. **.envファイルのセキュリティ対策**
 
@@ -101,8 +104,9 @@ DeepL Translation Tool (PHP)
    - PDF / DOC / DOCX: `pdf` / `docx` / `txt`（`txt` は DeepL で `docx` を取得後にサーバ側でテキスト抽出）
    - XLSX: `xlsx`
    - PPTX: `pptx`
-4. **DeepLへ送信** – アップロードされたファイルを DeepL の Document API に送信して翻訳します。
-5. **出力保存・リンク表示** – 翻訳結果は `downloads/` ディレクトリに保存され、ダウンロードリンクが表示されます。
+4. **用語集の選択（任意）** – `.env` の `DEEPL_GLOSSARY_ID` が自動入力されます。ドロップダウンから既存の用語集を選ぶか、未選択のまま送信すると用語集無しで翻訳します。手動入力も可能で、DeepLの仕様上、例えば日本語↔英語など対応する言語ペアのみ利用できます。
+5. **DeepLへ送信** – アップロードされたファイルを DeepL の Document API に送信して翻訳します。
+6. **出力保存・リンク表示** – 翻訳結果は `downloads/` ディレクトリに保存され、ダウンロードリンクが表示されます。
 
 ### 言語とファイル名の規約
 

--- a/translate.php
+++ b/translate.php
@@ -37,6 +37,7 @@ if ($apiKey === '') {
 }
 $apiBase = rtrim(env_non_empty('DEEPL_API_BASE'), '/');
 $debug   = filter_var(env_non_empty('APP_DEBUG'), FILTER_VALIDATE_BOOLEAN);
+$defaultGlossary = env_non_empty('DEEPL_GLOSSARY_ID');
 
 // Debug helpers
 function debug_log(string $msg): void {
@@ -144,6 +145,9 @@ $filename = $_POST['filename'] ?? '';
 $outputFormat = trim($_POST['output_format'] ?? '');
 $targetLangIn = strtoupper(trim($_POST['target_lang'] ?? ''));
 $glossaryId = trim($_POST['glossary_id'] ?? '');
+if ($glossaryId === '') {
+    $glossaryId = $defaultGlossary;
+}
 // Normalize and validate target language
 if ($targetLangIn === 'EN') { $targetLangIn = 'EN-US'; }
 if (!in_array($targetLangIn, ['JA','EN-US','EN-GB'], true)) {

--- a/upload_file.php
+++ b/upload_file.php
@@ -96,6 +96,7 @@ if ($apiKey === '') {
     $apiKey = env_non_empty('DEEPL_AUTH_KEY');
 }
 $apiBase = rtrim(env_non_empty('DEEPL_API_BASE'), '/');
+$defaultGlossary = env_non_empty('DEEPL_GLOSSARY_ID');
 if ($step === 'confirm' && $apiKey !== '' && $apiBase !== '') {
     $ch = curl_init($apiBase . '/glossaries?auth_key=' . rawurlencode($apiKey));
     curl_setopt_array($ch, [
@@ -312,16 +313,16 @@ function count_chars_local(string $path): int|false {
           <?php if ($glossaries): ?>
             <label for="glossary_id">用語集：</label>
             <select name="glossary_id" id="glossary_id">
-              <option value="">未使用</option>
+              <option value="" <?= $defaultGlossary === '' ? 'selected' : '' ?>>未使用</option>
               <?php foreach ($glossaries as $g): ?>
-                <option value="<?= h($g['glossary_id']) ?>" data-source-lang="<?= h($g['source_lang'] ?? '') ?>" data-target-lang="<?= h($g['target_lang'] ?? '') ?>">
+                <option value="<?= h($g['glossary_id']) ?>" data-source-lang="<?= h($g['source_lang'] ?? '') ?>" data-target-lang="<?= h($g['target_lang'] ?? '') ?>" <?= $g['glossary_id'] === $defaultGlossary ? 'selected' : '' ?>>
                   <?= h(($g['name'] ?? $g['glossary_id']) . ' (' . ($g['source_lang'] ?? '') . '→' . ($g['target_lang'] ?? '') . ')') ?>
                 </option>
               <?php endforeach; ?>
             </select>
           <?php else: ?>
             <label for="glossary_id">用語集ID：</label>
-            <input type="text" name="glossary_id" id="glossary_id">
+            <input type="text" name="glossary_id" id="glossary_id" value="<?= h($defaultGlossary) ?>">
           <?php endif; ?>
           <button type="submit">翻訳を開始</button>
         </form>


### PR DESCRIPTION
## Summary
- document DEEPL_GLOSSARY_ID in `.env` and usage instructions
- allow default glossary ID via environment and UI selection

## Testing
- `php -l upload_file.php`
- `php -l translate.php`
- `composer validate --no-check-all` *(fails: lock file is not up to date)*

------
https://chatgpt.com/codex/tasks/task_e_68ba423e833c83319e3fbd69fcc08e35