### PR TITLE
Add DeepL glossary management pages

### DIFF
--- a/downloads.php
+++ b/downloads.php
@@ -165,13 +165,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 <header>
   <h1>翻訳済みファイル一覧</h1>
 </header>
-<aside>
-  <ul>
-    <li><a href="upload_file.php">ファイル アップロード</a></li>
-    <li><a href="downloads.php">翻訳済みDL</a></li>
-    <li><a href="manage.php">ファイル管理</a></li>
-  </ul>
-</aside>
+  <aside>
+    <ul>
+      <li><a href="upload_file.php">ファイル アップロード</a></li>
+      <li><a href="downloads.php">翻訳済みDL</a></li>
+      <li><a href="manage.php">ファイル管理</a></li>
+      <li><a href="glossary.php">用語集管理</a></li>
+    </ul>
+  </aside>
 <main>
   <div class="card">
   <?php if (isset($_GET['done'])): ?>

--- a/glossary.php
+++ b/glossary.php
@@ -1,0 +1,170 @@
+<?php
+session_start();
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/common.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+if (file_exists(__DIR__ . '/.env')) {
+    $dotenv->load();
+}
+
+function env_non_empty(string $key): string {
+    $candidates = [];
+    if (array_key_exists($key, $_ENV)) {
+        $candidates[] = $_ENV[$key];
+    }
+    if (array_key_exists($key, $_SERVER)) {
+        $candidates[] = $_SERVER[$key];
+    }
+    $getenv = getenv($key);
+    if ($getenv !== false) {
+        $candidates[] = $getenv;
+    }
+    foreach ($candidates as $v) {
+        if (is_string($v)) {
+            $t = trim($v);
+            if ($t !== '') {
+                return $t;
+            }
+        }
+    }
+    return '';
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'GET') {
+    $_SESSION['csrf_token'] = bin2hex(random_bytes(32));
+}
+
+$apiKey = env_non_empty('DEEPL_API_KEY');
+if ($apiKey === '') {
+    $apiKey = env_non_empty('DEEPL_AUTH_KEY');
+}
+$apiBase = rtrim(env_non_empty('DEEPL_API_BASE'), '/');
+$glossaries = [];
+if ($apiKey !== '' && $apiBase !== '') {
+    $ch = curl_init($apiBase . '/glossaries?auth_key=' . rawurlencode($apiKey));
+    curl_setopt_array($ch, [
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_HTTPHEADER => ['Authorization: DeepL-Auth-Key ' . $apiKey],
+        CURLOPT_CONNECTTIMEOUT => 15,
+        CURLOPT_TIMEOUT => 60,
+    ]);
+    $res = curl_exec($ch);
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($res !== false && $code < 400) {
+        $data = json_decode($res, true);
+        if (isset($data['glossaries']) && is_array($data['glossaries'])) {
+            $glossaries = $data['glossaries'];
+        }
+    }
+}
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>用語集管理</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<?php include 'includes/spinner.php'; ?>
+<header>
+  <h1>用語集管理</h1>
+  <nav><a href="index.html">トップに戻る</a></nav>
+</header>
+
+<aside>
+  <ul>
+    <li><a href="upload_file.php">ファイル アップロード</a></li>
+    <li><a href="downloads.php">翻訳済みDL</a></li>
+    <li><a href="manage.php">ファイル管理</a></li>
+    <li><a href="glossary.php">用語集管理</a></li>
+  </ul>
+</aside>
+
+<main>
+<div class="card">
+<h2>用語集一覧</h2>
+
+<?php if (empty($glossaries)): ?>
+<p>用語集がありません。</p>
+<?php else: ?>
+<table class="data-table">
+<thead><tr><th>名前</th><th>言語</th><th>項目数</th><th>操作</th></tr></thead>
+<tbody>
+<?php foreach ($glossaries as $g): ?>
+<tr>
+  <td><?= h($g['name'] ?? '') ?></td>
+  <td><?= h(($g['source_lang'] ?? '') . ' → ' . ($g['target_lang'] ?? '')) ?></td>
+  <td><?= h($g['entry_count'] ?? '') ?></td>
+  <td>
+    <form method="post" action="glossary_delete.php" onsubmit="return confirm('削除しますか？');">
+      <input type="hidden" name="csrf_token" value="<?= h($_SESSION['csrf_token'] ?? '') ?>">
+      <input type="hidden" name="id" value="<?= h($g['glossary_id']) ?>">
+      <button type="submit">削除</button>
+    </form>
+  </td>
+</tr>
+<?php endforeach; ?>
+</tbody>
+</table>
+<?php endif; ?>
+
+<h2 style="margin-top:20px;">＋新規用語集</h2>
+<form method="post" action="glossary_save.php" id="glossary-form">
+  <input type="hidden" name="csrf_token" value="<?= h($_SESSION['csrf_token'] ?? '') ?>">
+  <div>
+    <label>名前: <input type="text" name="name" required></label>
+  </div>
+  <table class="data-table" id="terms-table">
+    <thead><tr><th>EN 原文</th><th>JA 訳文</th><th></th></tr></thead>
+    <tbody>
+      <tr>
+        <td><input type="text" name="terms[0][source]" required></td>
+        <td><input type="text" name="terms[0][target]" required></td>
+        <td><button type="button" class="remove-row">－</button></td>
+      </tr>
+    </tbody>
+  </table>
+  <button type="button" id="add-row">＋行追加</button>
+  <div class="action-btn">
+    <button type="submit">保存</button>
+  </div>
+</form>
+</div>
+</main>
+<footer>
+  &copy; 2025 翻訳ツール
+</footer>
+<script src="spinner.js"></script>
+<script>
+document.getElementById('add-row').addEventListener('click', function(){
+  const tbody = document.querySelector('#terms-table tbody');
+  const idx = tbody.children.length;
+  const tr = document.createElement('tr');
+  tr.innerHTML = '<td><input type="text" name="terms['+idx+'][source]" required></td>' +
+    '<td><input type="text" name="terms['+idx+'][target]" required></td>' +
+    '<td><button type="button" class="remove-row">－</button></td>';
+  tbody.appendChild(tr);
+});
+
+document.getElementById('terms-table').addEventListener('click', function(e){
+  if (e.target.classList.contains('remove-row')) {
+    const tbody = document.querySelector('#terms-table tbody');
+    if (tbody.children.length > 1) {
+      e.target.closest('tr').remove();
+    }
+  }
+});
+
+document.getElementById('glossary-form').addEventListener('submit', function(){
+  showSpinner('作成中…');
+});
+
+Array.from(document.querySelectorAll('form[action="glossary_delete.php"]')).forEach(function(f){
+  f.addEventListener('submit', function(){ showSpinner('削除中…'); });
+});
+</script>
+</body>
+</html>

--- a/glossary_delete.php
+++ b/glossary_delete.php
@@ -1,0 +1,74 @@
+<?php
+session_start();
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/common.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+if (file_exists(__DIR__ . '/.env')) {
+    $dotenv->load();
+}
+
+function env_non_empty(string $key): string {
+    $candidates = [];
+    if (array_key_exists($key, $_ENV)) {
+        $candidates[] = $_ENV[$key];
+    }
+    if (array_key_exists($key, $_SERVER)) {
+        $candidates[] = $_SERVER[$key];
+    }
+    $getenv = getenv($key);
+    if ($getenv !== false) {
+        $candidates[] = $getenv;
+    }
+    foreach ($candidates as $v) {
+        if (is_string($v)) {
+            $t = trim($v);
+            if ($t !== '') {
+                return $t;
+            }
+        }
+    }
+    return '';
+}
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    http_response_code(405);
+    exit('Method Not Allowed');
+}
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+    http_response_code(400);
+    exit('Invalid CSRF token');
+}
+$id = trim($_POST['id'] ?? '');
+if ($id === '') {
+    http_response_code(400);
+    exit('Invalid ID');
+}
+
+$apiKey = env_non_empty('DEEPL_API_KEY');
+if ($apiKey === '') {
+    $apiKey = env_non_empty('DEEPL_AUTH_KEY');
+}
+$apiBase = rtrim(env_non_empty('DEEPL_API_BASE'), '/');
+if ($apiKey === '' || $apiBase === '') {
+    http_response_code(500);
+    exit('DeepL API未設定');
+}
+
+$ch = curl_init($apiBase . '/glossaries/' . rawurlencode($id));
+curl_setopt_array($ch, [
+    CURLOPT_CUSTOMREQUEST => 'DELETE',
+    CURLOPT_RETURNTRANSFER => true,
+    CURLOPT_HTTPHEADER => ['Authorization: DeepL-Auth-Key ' . $apiKey],
+    CURLOPT_CONNECTTIMEOUT => 15,
+    CURLOPT_TIMEOUT => 60,
+]);
+$res = curl_exec($ch);
+$code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+curl_close($ch);
+if ($res !== false && $code < 400) {
+    header('Location: glossary.php?deleted=1');
+    exit;
+}
+header('Location: glossary.php?error=1');
+exit;

--- a/glossary_save.php
+++ b/glossary_save.php
@@ -1,0 +1,119 @@
+<?php
+session_start();
+require_once __DIR__ . '/vendor/autoload.php';
+require_once __DIR__ . '/includes/common.php';
+
+$dotenv = Dotenv\Dotenv::createImmutable(__DIR__);
+if (file_exists(__DIR__ . '/.env')) {
+    $dotenv->load();
+}
+
+function env_non_empty(string $key): string {
+    $candidates = [];
+    if (array_key_exists($key, $_ENV)) {
+        $candidates[] = $_ENV[$key];
+    }
+    if (array_key_exists($key, $_SERVER)) {
+        $candidates[] = $_SERVER[$key];
+    }
+    $getenv = getenv($key);
+    if ($getenv !== false) {
+        $candidates[] = $getenv;
+    }
+    foreach ($candidates as $v) {
+        if (is_string($v)) {
+            $t = trim($v);
+            if ($t !== '') {
+                return $t;
+            }
+        }
+    }
+    return '';
+}
+
+if (!hash_equals($_SESSION['csrf_token'] ?? '', $_POST['csrf_token'] ?? '')) {
+    http_response_code(400);
+    exit('Invalid CSRF token');
+}
+
+$name = trim($_POST['name'] ?? '');
+$terms = $_POST['terms'] ?? [];
+
+$rows = [];
+if (is_array($terms)) {
+    foreach ($terms as $pair) {
+        $src = trim($pair['source'] ?? '');
+        $dst = trim($pair['target'] ?? '');
+        if ($src !== '' && $dst !== '') {
+            $rows[] = $src . "\t" . $dst;
+        }
+    }
+}
+
+$errors = [];
+if ($name === '') {
+    $errors[] = '名前を入力してください';
+}
+if (empty($rows)) {
+    $errors[] = '用語を入力してください';
+}
+
+$apiKey = env_non_empty('DEEPL_API_KEY');
+if ($apiKey === '') {
+    $apiKey = env_non_empty('DEEPL_AUTH_KEY');
+}
+$apiBase = rtrim(env_non_empty('DEEPL_API_BASE'), '/');
+if ($apiKey === '' || $apiBase === '') {
+    $errors[] = 'DeepL APIの設定が必要です';
+}
+
+if (empty($errors)) {
+    $payload = [
+        'name' => $name,
+        'source_lang' => 'en',
+        'target_lang' => 'ja',
+        'entries' => implode("\n", $rows),
+        'entries_format' => 'tsv',
+    ];
+    $ch = curl_init($apiBase . '/glossaries');
+    curl_setopt_array($ch, [
+        CURLOPT_POST => true,
+        CURLOPT_RETURNTRANSFER => true,
+        CURLOPT_POSTFIELDS => http_build_query($payload),
+        CURLOPT_HTTPHEADER => ['Authorization: DeepL-Auth-Key ' . $apiKey],
+        CURLOPT_CONNECTTIMEOUT => 15,
+        CURLOPT_TIMEOUT => 60,
+    ]);
+    $res = curl_exec($ch);
+    $code = curl_getinfo($ch, CURLINFO_HTTP_CODE);
+    curl_close($ch);
+    if ($res !== false && $code < 400) {
+        header('Location: glossary.php?created=1');
+        exit;
+    } else {
+        $errors[] = '用語集の作成に失敗しました';
+    }
+}
+?>
+<!doctype html>
+<html lang="ja">
+<head>
+<meta charset="utf-8">
+<title>用語集保存エラー</title>
+<link rel="stylesheet" href="style.css">
+</head>
+<body>
+<header>
+  <h1>用語集保存エラー</h1>
+  <nav><a href="index.html">トップに戻る</a></nav>
+</header>
+<main>
+<div class="card">
+  <?php foreach ($errors as $e): ?>
+    <p style="color:red;"><?= h($e) ?></p>
+  <?php endforeach; ?>
+  <p><a href="glossary.php">戻る</a></p>
+</div>
+</main>
+</body>
+</html>

--- a/index.html
+++ b/index.html
@@ -28,6 +28,7 @@
       <li><a href="upload_file.php">ファイル アップロード</a></li>
       <li><a href="downloads.php">翻訳済みDL</a></li>
       <li><a href="manage.php">ファイル管理</a></li>
+      <li><a href="glossary.php">用語集管理</a></li>
     </ul>
   </aside>
   <main>

--- a/manage.php
+++ b/manage.php
@@ -150,6 +150,7 @@ function cost_jpy(int $c): int {
     <li><a href="upload_file.php">ファイル アップロード</a></li>
     <li><a href="downloads.php">翻訳済みDL</a></li>
     <li><a href="manage.php">ファイル管理</a></li>
+    <li><a href="glossary.php">用語集管理</a></li>
   </ul>
 </aside>
 

--- a/upload_file.php
+++ b/upload_file.php
@@ -274,6 +274,7 @@ function count_chars_local(string $path): int|false {
       <li><a href="upload_file.php">ファイル アップロード</a></li>
       <li><a href="downloads.php">翻訳済みDL</a></li>
       <li><a href="manage.php">ファイル管理</a></li>
+      <li><a href="glossary.php">用語集管理</a></li>
     </ul>
   </aside>
 


### PR DESCRIPTION
## Summary
- Add glossary management UI that lists existing DeepL glossaries and allows creation/deletion
- Implement handlers to save new glossaries and delete existing ones via DeepL API
- Link glossary management page from navigation menus

## Testing
- `php -l glossary.php`
- `php -l glossary_save.php`
- `php -l glossary_delete.php`
- `php -l upload_file.php`
- `php -l downloads.php`
- `php -l manage.php`


------
https://chatgpt.com/codex/tasks/task_e_68ba529cd52c8331b697d8207318c429